### PR TITLE
Update manifest.json to add new mandatory property `editorKey`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,6 @@
   "id": "00000000",
   "api": "1.0.0",
   "main": "dist/code.js",
-  "ui": "dist/ui.html"
+  "ui": "dist/ui.html",
+  "editorKey": ["figma"]
 }


### PR DESCRIPTION
Hi!
Thanks a lot for your template! I propose you to fix this warning by adding the new property called `editorKey` in `manifest.json`.

![image](https://user-images.githubusercontent.com/9600228/132027395-76dc31da-c234-4dbf-8212-81ac847da07c.png)

Feel free if you have questions :-)