### PR TITLE
Update Quickstart Guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This template contains the react example as shown on [Figma Docs](https://www.fi
 ## Quickstart
 * Run `yarn` to install dependencies.
 * Run `yarn build:watch` to start webpack in watch mode.
-* Open `Figma` -> `Plugins` -> `Development` -> `New Plugin...` and choose `manifest.json` file from this repo.
+* Open `Figma` -> `Plugins` -> `Development` -> `Import plugin from manifest...` and choose `manifest.json` file from this repo.
 
 ⭐ To change the UI of your plugin (the react code), start editing [App.tsx](./src/app/components/App.tsx).  
 ⭐ To interact with the Figma API edit [controller.ts](./src/plugin/controller.ts).  


### PR DESCRIPTION
Hello. I found a minor thing that needs to be changed.

The menu item to create Figma plugin from `manifest.json` has been changed.
When selected `New Plugin...` Figma generates menifest.json automatically. It needs to be changed to select `Import plugin from manifest...` to use `manifest.json` of this repo.

 Thanks for creating and maintaining useful template.